### PR TITLE
Add a test with unquoted zero and double encoded utf-8

### DIFF
--- a/t/02_api.t
+++ b/t/02_api.t
@@ -54,6 +54,7 @@ my $meta_yaml = catfile( test_data_directory(), 'META-VR.yml' );
 my $yaml_meta = catfile( test_data_directory(), 'yaml.meta' );
 my $json_meta = catfile( test_data_directory(), 'json.meta' );
 my $bare_yaml_meta = catfile( test_data_directory(), 'bareyaml.meta' );
+my $CL018_yaml_meta = catfile( test_data_directory(), 'CL018_yaml.meta' );
 
 ### YAML tests
 {
@@ -78,6 +79,14 @@ my $bare_yaml_meta = catfile( test_data_directory(), 'bareyaml.meta' );
   is(Parse::CPAN::Meta->yaml_backend(), 'CPAN::Meta::YAML', 'yaml_backend()');
   my $from_yaml = Parse::CPAN::Meta->load_file( $bare_yaml_meta );
   is_deeply($from_yaml, $want, "load from bare YAML .meta file results in expected data");
+}
+
+{
+  local $ENV{PERL_YAML_BACKEND}; # ensure we get CPAN::META::YAML
+
+  is(Parse::CPAN::Meta->yaml_backend(), 'CPAN::Meta::YAML', 'yaml_backend()');
+  my $from_yaml = Parse::CPAN::Meta->load_file( $CL018_yaml_meta );
+  like($from_yaml->{x_contributors}[5], qr/Olivier Mengu/, "Open question: what to expect from double encoded UTF-8");
 }
 
 {

--- a/t/data/CL018_yaml.meta
+++ b/t/data/CL018_yaml.meta
@@ -1,0 +1,75 @@
+{
+   "abstract" : "Lexical Analyzer for Perl5",
+   "author" : [
+      "Masaaki Goshima (goccy) <goccy(at)cpan.org>"
+   ],
+   "dynamic_config" : 0,
+   "generated_by" : "Module::Build version 0.4205",
+   "license" : [
+      "perl_5"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : "2"
+   },
+   "name" : "Compiler-Lexer",
+   "no_index" : {
+      "directory" : [
+         "t",
+         "examples",
+         "builder"
+      ]
+   },
+   "prereqs" : {
+      "build" : {
+         "requires" : {
+            "ExtUtils::CBuilder" : "0"
+         }
+      },
+      "configure" : {
+         "requires" : {
+            "Module::Build" : "0.38",
+            "Module::Build::XSUtil" : "0.06"
+         }
+      }
+   },
+   "provides" : {
+      "Compiler::Lexer" : {
+         "file" : "lib/Compiler/Lexer.pm",
+         "version" : "0.18"
+      },
+      "Compiler::Lexer::Kind" : {
+         "file" : "lib/Compiler/Lexer/Constants.pm"
+      },
+      "Compiler::Lexer::SyntaxType" : {
+         "file" : "lib/Compiler/Lexer/Constants.pm"
+      },
+      "Compiler::Lexer::Token" : {
+         "file" : "lib/Compiler/Lexer/Token.pm"
+      },
+      "Compiler::Lexer::TokenType" : {
+         "file" : "lib/Compiler/Lexer/Constants.pm"
+      }
+   },
+   "release_status" : "stable",
+   "resources" : {
+      "bugtracker" : {
+         "web" : "https://github.com/goccy/p5-Compiler-Lexer/issues"
+      },
+      "homepage" : "https://github.com/goccy/p5-Compiler-Lexer",
+      "repository" : {
+         "type" : "git",
+         "url" : "git://github.com/goccy/p5-Compiler-Lexer.git"
+      }
+   },
+   "version" : "0.18",
+   "x_contributors" : [
+      "tokuhirom <tokuhirom@gmail.com>",
+      "Reini Urban <rurban@cpanel.net>",
+      "Fumihiro Itoh <fmhrit@gmail.com>",
+      "Masaaki Goshima <masaaki.goshima@mixi.co.jp>",
+      "moznion <moznion@gmail.com>",
+      "Olivier MenguÃ© <dolmen@cpan.org>",
+      "Masaaki Goshima <goccy54@gmail.com>"
+   ]
+}


### PR DESCRIPTION
  - test file was found in the wild: GOCCY/Compiler-Lexer-0.18.tar.gz built
    with LEONT/Module-Build-0.4205.tar.gz produced it as MYMETA.json
  - perl 5.8.5 trips over it, many other perls can parse it
  - open question is how they deal with the double encoded utf-8