### PR TITLE
FAILING: test utf8 content in json and yaml

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,8 +5,8 @@ license = Perl_5
 copyright_holder = Adam Kennedy and Contributors
 
 [Encoding]
-encoding = Latin-1
-filename = t/data/BadMETA.yml
+encoding = bytes
+match = ^t/data/
 
 [Prereqs]
 CPAN::Meta::YAML = 0.011

--- a/t/02_api.t
+++ b/t/02_api.t
@@ -17,6 +17,7 @@ use Parse::CPAN::Meta;
 use Parse::CPAN::Meta::Test;
 # use Test::More skip_all => 'Temporarily ignoring failing test';
 use Test::More 'no_plan';
+use utf8;
 
 #####################################################################
 # Testing that Perl::Smith config files work
@@ -47,6 +48,9 @@ my $want = {
      "repository" => "git://git.codesimply.com/Version-Requirements.git"
   },
   "version" => "0.101010",
+  "x_contributors" => [
+    "Dagfinn Ilmari Mannsåker <ilmari\@ilmari.org>",
+  ],
 };
 
 my $meta_json = catfile( test_data_directory(), 'META-VR.json' );

--- a/t/data/META-VR.json
+++ b/t/data/META-VR.json
@@ -25,6 +25,9 @@
    "resources" : {
       "repository" : "git://git.codesimply.com/Version-Requirements.git"
    },
-   "version" : "0.101010"
+   "version" : "0.101010",
+   "x_contributors" : [
+      "Dagfinn Ilmari Mannsåker <ilmari@ilmari.org>",
+   ]
 }
 

--- a/t/data/META-VR.yml
+++ b/t/data/META-VR.yml
@@ -20,3 +20,5 @@ requires:
 resources:
   repository: git://git.codesimply.com/Version-Requirements.git
 version: 0.101010
+x_contributors:
+  - 'Dagfinn Ilmari Mannsåker <ilmari@ilmari.org>'

--- a/t/data/bareyaml.meta
+++ b/t/data/bareyaml.meta
@@ -19,3 +19,5 @@ requires:
 resources:
   repository: git://git.codesimply.com/Version-Requirements.git
 version: 0.101010
+x_contributors:
+  - 'Dagfinn Ilmari Mannsåker <ilmari@ilmari.org>'

--- a/t/data/json.meta
+++ b/t/data/json.meta
@@ -25,6 +25,9 @@
    "resources" : {
       "repository" : "git://git.codesimply.com/Version-Requirements.git"
    },
-   "version" : "0.101010"
+   "version" : "0.101010",
+   "x_contributors" : [
+      "Dagfinn Ilmari Mannsåker <ilmari@ilmari.org>",
+   ]
 }
 

--- a/t/data/yaml.meta
+++ b/t/data/yaml.meta
@@ -20,3 +20,5 @@ requires:
 resources:
   repository: git://git.codesimply.com/Version-Requirements.git
 version: 0.101010
+x_contributors:
+  - 'Dagfinn Ilmari Mannsåker <ilmari@ilmari.org>'


### PR DESCRIPTION
not a PR yet but an open issue - I noticed there was no testing of utf8 meta content, so I set about writing some, but they fail. I'm not sure if there is an incorrect assumption here, since we do know parsing works properly in the wild.

(Written via adding support for more json and yaml backends to the code... fixing this is a prerequisite.)